### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/lambdas.tf
+++ b/lambdas.tf
@@ -126,7 +126,7 @@ resource "aws_lambda_function" "sourcefunc" {
   function_name = "s3-bucket-acl"
   role          = aws_iam_role.iam_for_sourcelambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
   environment {
     variables = {
       rolearn = "arn:aws:iam::${var.account_b}:role/crossiam_for_sourcelambda"
@@ -298,7 +298,7 @@ resource "aws_lambda_function" "destinationfunc" {
   function_name = "s3-bucket-acl"
   role          = aws_iam_role.iam_for_destinationlambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
   environment {
     variables = {
       rolearn = "arn:aws:iam::${var.account_b}:role/crossiam_for_destinationlambda"


### PR DESCRIPTION
CloudFormation templates in aws-terraform-cross-account-kinesis-example have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.